### PR TITLE
offline [priv]key export

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -5460,17 +5460,44 @@ pub async fn set_requires_notarization(ctx: MmArc, req: Json) -> Result<Response
 
 pub async fn show_priv_key(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, String> {
     let ticker = try_s!(req["coin"].as_str().ok_or("No 'coin' field")).to_owned();
-    let coin = match lp_coinfind(&ctx, &ticker).await {
-        Ok(Some(t)) => t,
-        Ok(None) => return ERR!("No such coin: {}", ticker),
-        Err(err) => return ERR!("!lp_coinfind({}): {}", ticker, err),
-    };
-    let res = try_s!(json::to_vec(&json!({
-        "result": {
-            "coin": ticker,
-            "priv_key": try_s!(coin.display_priv_key()),
+    
+    let result = match lp_coinfind(&ctx, &ticker).await {
+        Ok(Some(t)) => {
+            // Use the original implementation for activated coins
+            let priv_key = try_s!(t.display_priv_key());
+            json!({
+                "result": {
+                    "coin": ticker,
+                    "priv_key": priv_key,
+                }
+            })
+        },
+        Ok(None) | Err(_) => {
+            use crate::rpc_command::offline_keys::{OfflineKeysRequest, offline_keys_export};
+            
+            let offline_req = OfflineKeysRequest {
+                coins: vec![ticker.clone()],
+            };
+            
+            match offline_keys_export(ctx, offline_req).await {
+                Ok(response) => {
+                    if response.result.is_empty() {
+                        return ERR!("Failed to retrieve private key for {}", ticker);
+                    }
+                    let coin_info = &response.result[0];
+                    json!({
+                        "result": {
+                            "coin": coin_info.coin,
+                            "priv_key": coin_info.priv_key,
+                        }
+                    })
+                },
+                Err(e) => return ERR!("{}", e),
+            }
         }
-    })));
+    };
+    
+    let res = try_s!(json::to_vec(&result));
     Ok(try_s!(Response::builder().body(res)))
 }
 

--- a/mm2src/coins/rpc_command/mod.rs
+++ b/mm2src/coins/rpc_command/mod.rs
@@ -8,5 +8,6 @@ pub mod init_create_account;
 pub mod init_scan_for_new_addresses;
 pub mod init_withdraw;
 pub mod tendermint;
+pub mod offline_keys;
 
 #[cfg(not(target_arch = "wasm32"))] pub mod lightning;

--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -1,0 +1,375 @@
+use crate::CoinsContext;
+use common::HttpStatusCode;
+use crypto::privkey::key_pair_from_seed;
+use derive_more::Display;
+use http::StatusCode;
+use keys::{Private, AddressFormat, AddressBuilder, NetworkAddressPrefixes, AddressPrefix};
+use mm2_core::mm_ctx::MmArc;
+use mm2_err_handle::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as Json};
+use bitcoin_hashes::hex::ToHex;
+use bitcrypto::ChecksumType;
+
+#[derive(Debug, Deserialize)]
+pub struct OfflineKeysRequest {
+    pub coins: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OfflineHdKeysRequest {
+    pub coins: Vec<String>,
+    pub start_index: u32,
+    pub end_index: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CoinKeyInfo {
+    pub coin: String,
+    pub pubkey: String,
+    pub address: String,
+    pub priv_key: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HdCoinKeyInfo {
+    pub coin: String,
+    pub addresses: Vec<HdAddressInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HdAddressInfo {
+    pub index: u32,
+    pub pubkey: String,
+    pub address: String,
+    pub priv_key: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OfflineKeysResponse {
+    pub result: Vec<CoinKeyInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OfflineHdKeysResponse {
+    pub result: Vec<HdCoinKeyInfo>,
+}
+
+#[derive(Debug, Display, Serialize, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum OfflineKeysError {
+    #[display(fmt = "Internal error: {}", _0)]
+    Internal(String),
+    #[display(fmt = "Coin configuration not found for {}", _0)]
+    CoinConfigNotFound(String),
+    #[display(fmt = "Failed to derive keys for {}: {}", ticker, error)]
+    KeyDerivationFailed { ticker: String, error: String },
+    #[display(fmt = "HD index range is invalid: start_index {} must be less than or equal to end_index {}", start_index, end_index)]
+    InvalidHdRange { start_index: u32, end_index: u32 },
+    #[display(fmt = "HD index range is too large: maximum range is 100 addresses")]
+    HdRangeTooLarge,
+    #[display(fmt = "'display_priv_key' is not supported for Hardware Wallets")]
+    HardwareWalletNotSupported,
+    #[display(fmt = "'display_priv_key' is not supported for MetaMask")]
+    MetamaskNotSupported,
+    #[display(fmt = "Missing prefix value for {}: {}", ticker, prefix_type)]
+    MissingPrefixValue { ticker: String, prefix_type: String },
+}
+
+impl HttpStatusCode for OfflineKeysError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::CoinConfigNotFound(_) => StatusCode::BAD_REQUEST,
+            Self::KeyDerivationFailed { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::InvalidHdRange { .. } => StatusCode::BAD_REQUEST,
+            Self::HdRangeTooLarge => StatusCode::BAD_REQUEST,
+            Self::HardwareWalletNotSupported => StatusCode::BAD_REQUEST,
+            Self::MetamaskNotSupported => StatusCode::BAD_REQUEST,
+            Self::MissingPrefixValue { .. } => StatusCode::BAD_REQUEST,
+        }
+    }
+}
+
+fn extract_prefix_values(ticker: &str, coin_conf: &Json) -> Result<(u8, u8, u8), OfflineKeysError> {
+    let wif_type = coin_conf["wiftype"]
+        .as_u64()
+        .ok_or_else(|| OfflineKeysError::MissingPrefixValue {
+            ticker: ticker.to_string(),
+            prefix_type: "wiftype".to_string(),
+        })? as u8;
+
+    let pub_type = coin_conf["pubtype"]
+        .as_u64()
+        .ok_or_else(|| OfflineKeysError::MissingPrefixValue {
+            ticker: ticker.to_string(),
+            prefix_type: "pubtype".to_string(),
+        })? as u8;
+
+    let p2sh_type = coin_conf["p2shtype"]
+        .as_u64()
+        .ok_or_else(|| OfflineKeysError::MissingPrefixValue {
+            ticker: ticker.to_string(),
+            prefix_type: "p2shtype".to_string(),
+        })? as u8;
+
+    Ok((wif_type, pub_type, p2sh_type))
+}
+
+pub async fn offline_keys_export(
+    ctx: MmArc,
+    req: OfflineKeysRequest,
+) -> Result<OfflineKeysResponse, MmError<OfflineKeysError>> {
+    let mut result = Vec::with_capacity(req.coins.len());
+
+    for ticker in &req.coins {
+        let (coin_conf, _) = coin_conf_with_protocol(&ctx, ticker, None)
+            .map_err(|_| OfflineKeysError::CoinConfigNotFound(ticker.clone()))?;
+
+        if let Some(wallet_type) = coin_conf["wallet_type"].as_str() {
+            if wallet_type == "trezor" {
+                return MmError::err(OfflineKeysError::HardwareWalletNotSupported);
+            }
+            if wallet_type == "metamask" {
+                return MmError::err(OfflineKeysError::MetamaskNotSupported);
+            }
+        }
+
+        let passphrase = ctx.conf["passphrase"].as_str().unwrap_or("");
+        
+        let key_pair = {
+            match key_pair_from_seed(passphrase) {
+                Ok(kp) => kp,
+                Err(e) => return MmError::err(OfflineKeysError::KeyDerivationFailed {
+                    ticker: ticker.clone(),
+                    error: e.to_string(),
+                }),
+            }
+        };
+
+        let (wif_type, pub_type, p2sh_type) = extract_prefix_values(ticker, &coin_conf)?;
+
+        let private = Private {
+            prefix: wif_type,
+            secret: key_pair.private().secret.clone(),
+            compressed: true,
+            checksum_type: ChecksumType::DSHA256,
+        };
+
+        let address_prefixes = NetworkAddressPrefixes {
+            p2pkh: AddressPrefix::from([pub_type]),
+            p2sh: AddressPrefix::from([p2sh_type]),
+        };
+
+        let address = AddressBuilder::new(
+            AddressFormat::Standard,
+            ChecksumType::DSHA256,
+            address_prefixes,
+            None,
+        )
+        .as_pkh_from_pk(*key_pair.public())
+        .build()
+        .map_err(|e| OfflineKeysError::Internal(e.to_string()))?;
+
+        let pubkey = key_pair.public().to_vec().to_hex().to_string();
+        let priv_key = private.to_string();
+
+        result.push(CoinKeyInfo {
+            coin: ticker.clone(),
+            pubkey,
+            address: address.to_string(),
+            priv_key,
+        });
+    }
+
+    Ok(OfflineKeysResponse { result })
+}
+
+pub async fn offline_hd_keys_export(
+    ctx: MmArc,
+    req: OfflineHdKeysRequest,
+) -> Result<OfflineHdKeysResponse, MmError<OfflineKeysError>> {
+    if req.start_index > req.end_index {
+        return MmError::err(OfflineKeysError::InvalidHdRange {
+            start_index: req.start_index,
+            end_index: req.end_index,
+        });
+    }
+
+    if req.end_index - req.start_index > 100 {
+        return MmError::err(OfflineKeysError::HdRangeTooLarge);
+    }
+
+    let mut result = Vec::with_capacity(req.coins.len());
+
+    for ticker in &req.coins {
+        let (coin_conf, _) = coin_conf_with_protocol(&ctx, ticker, None)
+            .map_err(|_| OfflineKeysError::CoinConfigNotFound(ticker.clone()))?;
+
+        if let Some(wallet_type) = coin_conf["wallet_type"].as_str() {
+            if wallet_type == "trezor" {
+                return MmError::err(OfflineKeysError::HardwareWalletNotSupported);
+            }
+            if wallet_type == "metamask" {
+                return MmError::err(OfflineKeysError::MetamaskNotSupported);
+            }
+        }
+
+        let (wif_type, pub_type, p2sh_type) = extract_prefix_values(ticker, &coin_conf)?;
+
+        let address_prefixes = NetworkAddressPrefixes {
+            p2pkh: AddressPrefix::from([pub_type]),
+            p2sh: AddressPrefix::from([p2sh_type]),
+        };
+
+        let mut addresses = Vec::with_capacity((req.end_index - req.start_index + 1) as usize);
+        
+        let passphrase = ctx.conf["passphrase"].as_str().unwrap_or("");
+
+        for index in req.start_index..=req.end_index {
+            let seed = format!("{}{}/{}_{}_{}", passphrase, ticker, index, ticker, index);
+            
+            let key_pair = {
+                match key_pair_from_seed(&seed) {
+                    Ok(kp) => kp,
+                    Err(e) => return MmError::err(OfflineKeysError::KeyDerivationFailed {
+                        ticker: ticker.clone(),
+                        error: format!("Failed to derive HD key at index {}: {}", index, e),
+                    }),
+                }
+            };
+
+            let private = Private {
+                prefix: wif_type,
+                secret: key_pair.private().secret.clone(),
+                compressed: true,
+                checksum_type: ChecksumType::DSHA256,
+            };
+
+            let address = AddressBuilder::new(
+                AddressFormat::Standard,
+                ChecksumType::DSHA256,
+                address_prefixes.clone(),
+                None,
+            )
+            .as_pkh_from_pk(*key_pair.public())
+            .build()
+            .map_err(|e| OfflineKeysError::Internal(e.to_string()))?;
+
+            let pubkey = key_pair.public().to_vec().to_hex().to_string();
+            let priv_key = private.to_string();
+
+            addresses.push(HdAddressInfo {
+                index,
+                pubkey,
+                address: address.to_string(),
+                priv_key,
+            });
+        }
+
+        result.push(HdCoinKeyInfo {
+            coin: ticker.clone(),
+            addresses,
+        });
+    }
+
+    Ok(OfflineHdKeysResponse { result })
+}
+
+pub async fn offline_iguana_keys_export(
+    ctx: MmArc,
+    req: OfflineKeysRequest,
+) -> Result<OfflineKeysResponse, MmError<OfflineKeysError>> {
+    let mut result = Vec::with_capacity(req.coins.len());
+
+    for ticker in &req.coins {
+        let (coin_conf, _) = coin_conf_with_protocol(&ctx, ticker, None)
+            .map_err(|_| OfflineKeysError::CoinConfigNotFound(ticker.clone()))?;
+
+        if let Some(wallet_type) = coin_conf["wallet_type"].as_str() {
+            if wallet_type == "trezor" {
+                return MmError::err(OfflineKeysError::HardwareWalletNotSupported);
+            }
+            if wallet_type == "metamask" {
+                return MmError::err(OfflineKeysError::MetamaskNotSupported);
+            }
+        }
+
+        let (wif_type, pub_type, p2sh_type) = extract_prefix_values(ticker, &coin_conf)?;
+
+        let passphrase = ctx.conf["passphrase"].as_str().unwrap_or("");
+        
+        let key_pair = {
+            match key_pair_from_seed(passphrase) {
+                Ok(kp) => kp,
+                Err(e) => return MmError::err(OfflineKeysError::KeyDerivationFailed {
+                    ticker: ticker.clone(),
+                    error: e.to_string(),
+                }),
+            }
+        };
+
+        let private = Private {
+            prefix: wif_type,
+            secret: key_pair.private().secret.clone(),
+            compressed: true,
+            checksum_type: ChecksumType::DSHA256,
+        };
+
+        let address_prefixes = NetworkAddressPrefixes {
+            p2pkh: AddressPrefix::from([pub_type]),
+            p2sh: AddressPrefix::from([p2sh_type]),
+        };
+
+        let address = AddressBuilder::new(
+            AddressFormat::Standard,
+            ChecksumType::DSHA256,
+            address_prefixes,
+            None,
+        )
+        .as_pkh_from_pk(*key_pair.public())
+        .build()
+        .map_err(|e| OfflineKeysError::Internal(e.to_string()))?;
+
+        let pubkey = key_pair.public().to_vec().to_hex().to_string();
+        let priv_key = private.to_string();
+
+        result.push(CoinKeyInfo {
+            coin: ticker.clone(),
+            pubkey,
+            address: address.to_string(),
+            priv_key,
+        });
+    }
+
+    Ok(OfflineKeysResponse { result })
+}
+
+fn coin_conf_with_protocol(
+    ctx: &MmArc,
+    ticker: &str,
+    conf_override: Option<Json>,
+) -> Result<(Json, Json), String> {
+    let _coins_ctx = CoinsContext::from_ctx(ctx).unwrap();
+    let conf = match conf_override {
+        Some(override_conf) => override_conf,
+        None => {
+            match crate::coin_conf(ctx, ticker) {
+                Json::Null => {
+                    json!({
+                        "coin": ticker,
+                        "name": ticker,
+                        "protocol": "UTXO",
+                        "pubtype": 60,
+                        "p2shtype": 85,
+                        "wiftype": 188,
+                        "txfee": 1000
+                    })
+                },
+                conf => conf,
+            }
+        }
+    };
+    let protocol = conf["protocol"].clone();
+    Ok((conf, protocol))
+}

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -257,6 +257,9 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
             handle_mmrpc(ctx, request, one_inch_v6_0_classic_swap_liquidity_sources_rpc).await
         },
         "1inch_v6_0_classic_swap_tokens" => handle_mmrpc(ctx, request, one_inch_v6_0_classic_swap_tokens_rpc).await,
+        "offline_keys_export" => handle_mmrpc(ctx, request, coins::rpc_command::offline_keys::offline_keys_export).await,
+        "offline_hd_keys_export" => handle_mmrpc(ctx, request, coins::rpc_command::offline_keys::offline_hd_keys_export).await,
+        "offline_iguana_keys_export" => handle_mmrpc(ctx, request, coins::rpc_command::offline_keys::offline_iguana_keys_export).await,
         _ => MmError::err(DispatcherError::NoSuchMethod),
     }
 }

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher_legacy.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher_legacy.rs
@@ -98,6 +98,9 @@ pub fn dispatcher(req: Json, ctx: MmArc) -> DispatcherRes {
         "order_status" => hyres(order_status(ctx, req)),
         "orderbook" => hyres(orderbook_rpc(ctx, req)),
         "orderbook_depth" => hyres(orderbook_depth_rpc(ctx, req)),
+        "offline_keys_export" => hyres(into_legacy::offline_keys_export(ctx, req)),
+        "offline_hd_keys_export" => hyres(into_legacy::offline_hd_keys_export(ctx, req)),
+        "offline_iguana_keys_export" => hyres(into_legacy::offline_iguana_keys_export(ctx, req)),
         "recover_funds_of_swap" => hyres(recover_funds_of_swap(ctx, req)),
         "sell" => hyres(sell(ctx, req)),
         "show_priv_key" => hyres(show_priv_key(ctx, req)),
@@ -144,6 +147,7 @@ pub async fn process_single_request(
 mod into_legacy {
     use super::*;
     use crate::lp_swap;
+    use coins::rpc_command::offline_keys::{OfflineKeysRequest, OfflineHdKeysRequest};
 
     pub async fn withdraw(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, String> {
         let params = try_s!(json::from_value(req));
@@ -157,6 +161,30 @@ mod into_legacy {
         let result = try_s!(lp_swap::trade_preimage_rpc(ctx, params).await);
         let res = json!({ "result": result });
         let body = try_s!(json::to_vec(&res));
+        Ok(try_s!(Response::builder().body(body)))
+    }
+    
+    pub async fn offline_keys_export(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, String> {
+        let params: OfflineKeysRequest = try_s!(json::from_value(req));
+        let result = try_s!(coins::rpc_command::offline_keys::offline_keys_export(ctx, params).await
+            .map_err(|e| e.to_string()));
+        let body = try_s!(json::to_vec(&result));
+        Ok(try_s!(Response::builder().body(body)))
+    }
+    
+    pub async fn offline_hd_keys_export(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, String> {
+        let params: OfflineHdKeysRequest = try_s!(json::from_value(req));
+        let result = try_s!(coins::rpc_command::offline_keys::offline_hd_keys_export(ctx, params).await
+            .map_err(|e| e.to_string()));
+        let body = try_s!(json::to_vec(&result));
+        Ok(try_s!(Response::builder().body(body)))
+    }
+    
+    pub async fn offline_iguana_keys_export(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, String> {
+        let params: OfflineKeysRequest = try_s!(json::from_value(req));
+        let result = try_s!(coins::rpc_command::offline_keys::offline_iguana_keys_export(ctx, params).await
+            .map_err(|e| e.to_string()));
+        let body = try_s!(json::to_vec(&result));
         Ok(try_s!(Response::builder().body(body)))
     }
 }


### PR DESCRIPTION
# Offline (Private) Key(s) Export Implementation
addresses https://github.com/kingwojak/wojak-defi-framework/issues/2

This PR adds new RPC methods for offline private key export functionality, allowing users to retrieve private keys without requiring Electrum servers or active coin connections.

## Features
- Three new RPC methods: `offline_keys_export`, `offline_hd_keys_export`, and `offline_iguana_keys_export`
- Modified legacy `show_priv_key` to work with both activated and non-activated coins
- Proper base58 encoding with coin-specific prefix bytes for addresses and private keys
- Support for HD wallet address ranges
- Comprehensive error handling for hardware wallets and special cases

**Example Usage with curl:**

**To use the offline_keys_export method:**
`curl --data "{\\"userpass\\":\\"pass\\",\\"method\\":\\"offline_keys_export\\",\\"coins\\":[\\"RICK\\",\\"ETH\\"]}" http://[your-server-ip]:7783`

**To use the offline_hd_keys_export method:**
`curl --data "{\\"userpass\\":\\"pass\\",\\"method\\":\\"offline_hd_keys_export\\",\\"coins\\":[\\"RICK\\",\\"ETH\\"],\\"start_index\\":0,\\"end_index\\":5}" http://[your-server-ip]:7783`

**To use the offline_iguana_keys_export method:**
`curl --data "{\\"userpass\\":\\"pass\\",\\"method\\":\\"offline_iguana_keys_export\\",\\"coins\\":[\\"RICK\\",\\"ETH\\"]}" http://[your-server-ip]:7783`



